### PR TITLE
Use a less restricting sass version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   },
   "dependencies": {
     "rollup-pluginutils": "^2.4.1",
-    "sass": "^1.38.1"
+    "sass": "^1"
   }
 }


### PR DESCRIPTION
This loosens up the `sass` version requirement a bit. Some projects might have older or newer versions and the plugin should allow for that.